### PR TITLE
feat: タスク編集機能

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -11,6 +11,25 @@ class TasksController < ApplicationController
     end
   end
 
+  def update
+  @task = current_user.tasks.find(params[:id])
+
+  # 編集
+  if params[:edit]
+    respond_to do |format|
+      format.turbo_stream
+    end
+    return
+  end
+
+  # 保存処理
+  if @task.update(task_params)
+    respond_to do |format|
+      format.turbo_stream
+    end
+  end
+end
+
   private
 
   def task_params

--- a/app/views/tasks/_edit.html.erb
+++ b/app/views/tasks/_edit.html.erb
@@ -1,0 +1,30 @@
+<%# =============================== %>
+<%# タスク1件を「編集」するパーシャル %>
+<%# =============================== %>
+
+<%# 表示用と同じ id にすることで %>
+<%# turbo_stream.replace で入れ替え可能になる %>
+<div id="task_<%= task.id %>">
+
+  <%# ---- 編集フォーム ---- %>
+  <%# model: task にすることで %>
+  <%# PATCH /tasks/:id が自動で呼ばれる %>
+  <%= form_with model: task do |f| %>
+
+    <div class="flex gap-2">
+
+      <%# タスク内容の編集欄 %>
+      <%= f.text_field :title,
+            class: "input input-sm input-bordered flex-1" %>
+
+      <%# 保存ボタン %>
+      <%# 押すと update が呼ばれ、edit パラメータは無いので %>
+      <%# 「表示パーシャル」に戻る %>
+      <%= f.submit "保存",
+            class: "btn btn-sm btn-primary" %>
+
+    </div>
+
+  <% end %>
+</div>
+

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,3 +1,26 @@
-<div class="p-2 border rounded">
-  <%= task.title %>
+<%# =============================== %>
+<%# タスク1件を「表示」するパーシャル %>
+<%# =============================== %>
+
+<%# Turbo Stream で差し替えるため、必ず一意な id をつける %>
+<%# update.turbo_stream.erb から replace される対象 %>
+<div id="task_<%= task.id %>"
+     class="input input-sm input-bordered w-full">
+
+  <%# ---- タスクの内容表示 ---- %>
+  <span class="flex-1">
+    <%= task.title %>
+  </span>
+
+  <%# ---- 編集ボタン ---- %>
+  <%# ・PATCH /tasks/:id に送る %>
+  <%# ・edit=true を渡して「編集モードにしたい」ことを controller に伝える %>
+  <%# ・data-turbo-stream を使うので画面遷移しない %>
+  <%= button_to "✏️",
+        task_path(task),
+        method: :patch,
+        params: { edit: true },
+        form: { data: { turbo_stream: true } },
+        class: "btn btn-sm " %>
+
 </div>

--- a/app/views/tasks/update.turbo_stream.erb
+++ b/app/views/tasks/update.turbo_stream.erb
@@ -1,0 +1,9 @@
+<% if params[:edit] %>
+  <%= turbo_stream.replace "task_#{@task.id}",
+        partial: "tasks/edit",
+        locals: { task: @task } %>
+<% else %>
+  <%= turbo_stream.replace "task_#{@task.id}",
+        partial: "tasks/task",
+        locals: { task: @task } %>
+<% end %>


### PR DESCRIPTION
# 概要
ホーム画面上でタスクを画面遷移なしに編集できるようにしました。  
Turbo Streams を用いて、タスク1行単位で表示状態と編集状態を切り替えられるようにしています。

# 実装内容
- タスクのインライン編集機能を実装
- 編集ボタン押下時に対象タスクを編集フォームへ切り替え

Closes #22
