### PR TITLE
feat: タスク削除機能

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -30,6 +30,16 @@ class TasksController < ApplicationController
   end
 end
 
+  def destroy
+    @task = current_user.tasks.find(params[:id])
+    @task.destroy
+
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to root_path }
+    end
+  end
+
   private
 
   def task_params

--- a/app/views/tasks/_edit.html.erb
+++ b/app/views/tasks/_edit.html.erb
@@ -4,27 +4,28 @@
 
 <%# 表示用と同じ id にすることで %>
 <%# turbo_stream.replace で入れ替え可能になる %>
-<div id="task_<%= task.id %>">
+<div id="task_<%= task.id %>"
+     class="flex items-center gap-2 rounded px-3 py-2">
 
-  <%# ---- 編集フォーム ---- %>
-  <%# model: task にすることで %>
-  <%# PATCH /tasks/:id が自動で呼ばれる %>
-  <%= form_with model: task do |f| %>
+  <%= form_with model: task,
+        class: "flex items-center gap-2 w-full" do |f| %>
 
-    <div class="flex gap-2">
+    <%# ---- タスク内容の編集欄 ---- %>
+    <%= f.text_field :title,
+          class: "input input-sm input-bordered flex-1" %>
 
-      <%# タスク内容の編集欄 %>
-      <%= f.text_field :title,
-            class: "input input-sm input-bordered flex-1" %>
+    <%# ---- 保存ボタン ---- %>
+    <%= f.submit "保存",
+          class: "btn btn-sm btn-primary" %>
 
-      <%# 保存ボタン %>
-      <%# 押すと update が呼ばれ、edit パラメータは無いので %>
-      <%# 「表示パーシャル」に戻る %>
-      <%= f.submit "保存",
-            class: "btn btn-sm btn-primary" %>
-
-    </div>
+    <%# ---- 削除ボタン（編集時のみ表示） ---- %>
+    <%= link_to "削除",
+      task_path(task),
+      data: {
+        turbo_method: :delete,
+        turbo_confirm: "削除しますか？"
+      },
+      class: "btn btn-sm btn-outline rounded-full" %>
 
   <% end %>
 </div>
-

--- a/app/views/tasks/destroy.turbo_stream.erb
+++ b/app/views/tasks/destroy.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.remove "task_#{@task.id}" %>


### PR DESCRIPTION
## 概要
TODOタスクを画面遷移なしで削除できる機能を実装しました。  
編集状態のときのみ削除ボタンを表示し、誤操作を防ぐUIとしています。

## 実装内容
- タスク削除用の `destroy` アクションを実装
- 編集状態のときのみ削除ボタンを表示するUIに調整
- 削除時に確認ダイアログを表示し、誤削除を防止

Closes #23
