### PR TITLE
feat: タスク インライン編集

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,15 +1,19 @@
 class TasksController < ApplicationController
   before_action :authenticate_user!
 
-  def create
-    @task = current_user.tasks.new(task_params)
+# app/controllers/tasks_controller.rb
+def create
+  @task = current_user.tasks.new(title: "")  # 空タイトルでもOK
+  @task.editing = true  # ← 追加直後は編集状態
 
-    if @task.save
-      # Turbo用（あとで書く）
-    else
-      # バリデーションエラー用
+  if @task.save
+    respond_to do |format|
+      format.turbo_stream
+      format.html { redirect_to root_path }
     end
   end
+end
+
 
   def update
   @task = current_user.tasks.find(params[:id])

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,4 @@
 class Task < ApplicationRecord
   belongs_to :user
+  attr_accessor :editing  # 仮想属性
 end

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -76,9 +76,11 @@
 
   <!-- ボタン -->
   <div id="task_form">
-    <%= render "tasks/form" %>
+    <%= button_to "タスク追加", tasks_path,
+        method: :post,
+        form: { data: { turbo: true } },
+        class: "btn btn-primary w-full" %>
   </div>
-</div>
 
 
   <!-- 習慣リスト -->

--- a/app/views/tasks/_edit.html.erb
+++ b/app/views/tasks/_edit.html.erb
@@ -1,31 +1,20 @@
-<%# =============================== %>
-<%# タスク1件を「編集」するパーシャル %>
-<%# =============================== %>
-
-<%# 表示用と同じ id にすることで %>
-<%# turbo_stream.replace で入れ替え可能になる %>
 <div id="task_<%= task.id %>"
-     class="flex items-center gap-2 rounded px-3 py-2">
+     class="flex items-center gap-2 p-2 rounded-lg shadow border-gray-100">
 
-  <%= form_with model: task,
-        class: "flex items-center gap-2 w-full" do |f| %>
+  <%= form_with model: task, class: "flex-1 flex items-center gap-2" do |f| %>
 
-    <%# ---- タスク内容の編集欄 ---- %>
+    <%# タイトル入力欄：枠なし、背景白、親divの薄い枠に統一 %>
     <%= f.text_field :title,
-          class: "input input-sm input-bordered flex-1" %>
+          class: "flex-1 h-9 px-2 rounded bg-white border-none focus:ring-0 focus:border-none placeholder-gray-400",
+          placeholder: "タスクを入力" %>
 
-    <%# ---- 保存ボタン ---- %>
-    <%= f.submit "保存",
-          class: "btn btn-sm btn-primary" %>
+    <%# 保存ボタン %>
+    <%= f.submit "保存", class: "btn btn-sm btn-primary h-9" %>
 
-    <%# ---- 削除ボタン（編集時のみ表示） ---- %>
-    <%= link_to "削除",
-      task_path(task),
-      data: {
-        turbo_method: :delete,
-        turbo_confirm: "削除しますか？"
-      },
-      class: "btn btn-sm btn-outline rounded-full" %>
+    <%# 削除ボタン %>
+    <%= link_to "削除", task_path(task),
+          data: { turbo_method: :delete },
+          class: "btn btn-sm btn-outline h-9" %>
 
   <% end %>
 </div>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,26 +1,12 @@
-<%# =============================== %>
-<%# タスク1件を「表示」するパーシャル %>
-<%# =============================== %>
-
-<%# Turbo Stream で差し替えるため、必ず一意な id をつける %>
-<%# update.turbo_stream.erb から replace される対象 %>
 <div id="task_<%= task.id %>"
-     class="input input-sm input-bordered w-full">
+     class="flex items-center gap-2 p-2 rounded-lg shadow border-gray-100 ">
 
-  <%# ---- タスクの内容表示 ---- %>
-  <span class="flex-1">
-    <%= task.title %>
-  </span>
+  <span class="flex-1 text-gray-700 h-9 flex items-center"><%= task.title %></span>
 
-  <%# ---- 編集ボタン ---- %>
-  <%# ・PATCH /tasks/:id に送る %>
-  <%# ・edit=true を渡して「編集モードにしたい」ことを controller に伝える %>
-  <%# ・data-turbo-stream を使うので画面遷移しない %>
-  <%= button_to "✏️",
-        task_path(task),
+  <%= button_to "編集", task_path(task),
         method: :patch,
         params: { edit: true },
-        form: { data: { turbo_stream: true } },
-        class: "btn btn-sm " %>
-
+        form: { data: { turbo_stream: true }, class: "flex items-center gap-1" },
+        class: "btn btn-sm btn-primary h-9" %>
 </div>
+

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -1,16 +1,10 @@
 <%# === 新規タスクを一覧の先頭に追加する === %>
 <%# "tasks" は homes/index.html.erb にある <div id="tasks"> %>
 <%# prepend = 一番上に差し込む（最新タスクを上に表示） %>
-<%= turbo_stream.prepend "tasks",
-      partial: "tasks/task",          # タスク1件分の見た目
+<%# append = 一番下に差し込む（最新タスクを下に表示） %>
+<%= turbo_stream.append "tasks",
+      partial: "tasks/edit",          # 編集用のパーシャルを使うことで編集モードで表示
       locals: { task: @task }       # controllerで作った @task を渡す
 %>
 
-
-<%# === 新規作成フォームを空に戻す === %>
-<%# "task_form" は フォームを囲っている <div id="task_form"> %>
-<%# replace = フォーム全体を描き直す %>
-<%= turbo_stream.replace "task_form",
-      partial: "tasks/form"         # Task.new を使うので入力欄が初期化される
-%>
 


### PR DESCRIPTION
# 概要

タスクの追加・編集・削除をすべて画面遷移なしで行えるよう、
Turbo を用いたインライン編集機能を実装しました。  

---

# 実装内容
- Turbo Stream を利用したタスクのインライン編集（表示 ⇄ 編集の切り替え）
- 新規タスク追加時に即編集状態になる挙動を実装
- 編集中のみ保存・削除ボタンを表示する UI に調整
- タスク削除時、画面遷移なしで即座に DOM から削除

---

Closes #24