### PR TITLE
feat: 習慣一覧表示

### DIFF
--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -1,6 +1,10 @@
 class HabitsController < ApplicationController
   before_action :authenticate_user!
 
+  def index
+    @habits = current_user.habits.order(created_at: :desc)
+  end
+
   def new
     @habit = Habit.new
   end

--- a/app/views/habits/index.html.erb
+++ b/app/views/habits/index.html.erb
@@ -1,2 +1,39 @@
-<h1>Habits#index</h1>
-<p>Find me in app/views/habits/index.html.erb</p>
+<h1 class="text-xl font-bold mb-6">習慣一覧</h1>
+
+<% if @habits.any? %>
+  <div class="space-y-3 mb-10">
+    <% @habits.each do |habit| %>
+      <div class="p-4 rounded-lg bg-white shadow border">
+        <div class="flex items-center justify-between">
+          <div>
+            <div class="font-medium text-lg">
+              <%= habit.title %>
+            </div>
+
+            <div class="text-sm text-gray-500">
+              <%= habit.start_date %> 〜 <%= habit.end_date %>
+              （<%= habit.total_days %>日間）
+            </div>
+
+            <div class="text-sm text-gray-600 mt-1">
+              <%= habit.current_day %> / <%= habit.total_days %>
+            </div>
+          </div>
+
+          <%= link_to "編集",
+                edit_habit_path(habit),
+                class: "btn btn-sm btn-outline" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% else %>
+  <p class="text-gray-400 mb-10">まだ習慣が登録されていません</p>
+<% end %>
+
+<!-- 👇 ここが新規登録ボタン -->
+<div class="fixed bottom-20 left-0 right-0 px-4">
+  <%= link_to " 習慣を新しく登録",
+        new_habit_path,
+        class: "btn btn-primary btn-lg w-full shadow-lg" %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,5 @@ Rails.application.routes.draw do
   root "homes#index"
   resource :home_memo, only: [ :update ]
   resources :tasks, only: [ :create, :update, :destroy ]
-  resources :habits, only: [ :new, :index, :create, :update, :destroy ]
+  resources :habits, only: [ :new, :index, :edit, :create, :update, :destroy ]
 end


### PR DESCRIPTION
## 概要

ユーザーが登録した習慣を一覧で確認できるようにするため、  
習慣一覧表示機能を実装しました。

---

## 実装内容

- 習慣一覧ページ（habits#index）を実装
- ログインユーザーに紐づく習慣のみを表示
- 習慣の開始日・終了日および期間（日数）を一覧に表示
- 習慣編集画面への導線（編集ボタン）を追加
- 新規習慣登録ページへの導線を画面下部に配置

---

Closes #29
