### PR TITLE
feat: 習慣削除

### DIFF
--- a/app/views/habits/index.html.erb
+++ b/app/views/habits/index.html.erb
@@ -20,9 +20,17 @@
             </div>
           </div>
 
-          <%= link_to "編集",
-                edit_habit_path(habit),
-                class: "btn btn-sm btn-outline" %>
+          <!-- 編集・削除ボタン -->
+          <div class="flex gap-2">
+  <%= link_to "編集",
+        edit_habit_path(habit),
+        class: "btn btn-sm btn-primary h-9" %>
+
+  <%= link_to "削除",
+      habit_path(habit),
+      data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+      class: "btn btn-sm btn-outline h-9" %>
+        </div>
         </div>
       </div>
     <% end %>
@@ -31,7 +39,7 @@
   <p class="text-gray-400 mb-10">まだ習慣が登録されていません</p>
 <% end %>
 
-<!-- 👇 ここが新規登録ボタン -->
+<!-- 新規登録ボタン -->
 <div class="fixed bottom-20 left-0 right-0 px-4">
   <%= link_to " 習慣を新しく登録",
         new_habit_path,


### PR DESCRIPTION
# 概要
習慣一覧画面から個別の習慣を削除できるようにしました。
削除ボタンは確認ダイアログ付きで安全に操作できます。

# 実装内容
- `HabitsController` に `destroy` アクションを追加
- 削除対象の習慣を `before_action :set_habit` で取得
- `index.html.erb` の習慣カードに「削除ボタン」を追加
  - ボタンはタスク一覧と同じデザインに統一（`btn-sm btn-outline h-9`）
  - Turbo 対応で削除後は即画面から消えるように設定

Closes #32