### PR TITLE
feat: 体重記録の新規登録

### DIFF
--- a/app/controllers/body_records_controller.rb
+++ b/app/controllers/body_records_controller.rb
@@ -1,0 +1,26 @@
+class BodyRecordsController < ApplicationController
+  before_action :authenticate_user!
+
+def index
+  @body_records = current_user.body_records.order(measured_on: :asc)
+  @body_record = current_user.body_records.new
+end
+
+def create
+  @body_record = current_user.body_records.new(body_record_params)
+  @body_record.measured_on ||= Date.today
+
+  if @body_record.save
+    redirect_to body_records_path, notice: "登録しました"
+  else
+    @body_records = current_user.body_records.order(measured_on: :asc)
+    render :index, status: :unprocessable_entity
+  end
+end
+
+private
+
+def body_record_params
+  params.require(:body_record).permit(:weight, :body_fat, :measured_on)
+end
+end

--- a/app/models/body_record.rb
+++ b/app/models/body_record.rb
@@ -1,0 +1,3 @@
+class BodyRecord < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
   has_many :habits, dependent: :destroy
   has_many :memos, dependent: :destroy
+  has_many :body_records, dependent: :destroy
 end

--- a/app/views/body_records/index.html.erb
+++ b/app/views/body_records/index.html.erb
@@ -1,0 +1,36 @@
+<!-- 入力フォーム -->
+<div class="fixed bottom-20 left-0 right-0 px-4">
+  <div class="bg-base-200 rounded-xl p-4 shadow-lg">
+
+    <%= form_with model: @body_record, url: body_records_path, local: true do |f| %>
+
+      <div class="flex gap-4 mb-4">
+        
+        <div class="flex-1">
+          <label class="text-sm">体重</label>
+          <div class="flex items-center gap-2">
+            <%= f.number_field :weight,
+                  step: 0.1,
+                  class: "input input-bordered w-full" %>
+            <span>kg</span>
+          </div>
+        </div>
+
+        <div class="flex-1">
+          <label class="text-sm">体脂肪</label>
+          <div class="flex items-center gap-2">
+            <%= f.number_field :body_fat,
+                  step: 0.1,
+                  class: "input input-bordered w-full" %>
+            <span>%</span>
+          </div>
+        </div>
+
+      </div>
+
+      <%= f.submit "入力",
+            class: "btn btn-primary w-full" %>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/devise/shared/_footer.html.erb
+++ b/app/views/devise/shared/_footer.html.erb
@@ -13,7 +13,7 @@
       <%= image_tag "memo.png", alt: "memo", class: "w-6 h-6 mb-1" %>
       memo
     </a>
-    <a href="/weights" class="flex flex-col items-center p-2 hover:text-pink-500">
+    <a href="/body_records" class="flex flex-col items-center p-2 hover:text-pink-500">
       <%= image_tag "weight.png", alt: "weight", class: "w-6 h-6 mb-1" %>
       weight
     </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,4 +26,5 @@ Rails.application.routes.draw do
     patch :toggle_check, on: :member
   end
   resources :memos
+  resources :body_records, only: [ :index, :create ]
 end

--- a/db/migrate/20260213033504_create_body_records.rb
+++ b/db/migrate/20260213033504_create_body_records.rb
@@ -1,0 +1,12 @@
+class CreateBodyRecords < ActiveRecord::Migration[7.2]
+  def change
+    create_table :body_records do |t|
+      t.float :weight
+      t.float :body_fat
+      t.date :measured_on
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_11_151345) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_13_033504) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "body_records", force: :cascade do |t|
+    t.float "weight"
+    t.float "body_fat"
+    t.date "measured_on"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_body_records_on_user_id"
+  end
 
   create_table "habit_checks", force: :cascade do |t|
     t.bigint "habit_id", null: false
@@ -88,6 +98,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_11_151345) do
     t.float "temp_min"
   end
 
+  add_foreign_key "body_records", "users"
   add_foreign_key "habit_checks", "habits"
   add_foreign_key "habits", "users"
   add_foreign_key "home_memos", "users"

--- a/test/fixtures/body_records.yml
+++ b/test/fixtures/body_records.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  weight: 1.5
+  body_fat: 1.5
+  measured_on: 2026-02-13
+  user: one
+
+two:
+  weight: 1.5
+  body_fat: 1.5
+  measured_on: 2026-02-13
+  user: two

--- a/test/models/body_record_test.rb
+++ b/test/models/body_record_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class BodyRecordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 概要
体重記録を新規登録できる入力フォームを実装しました。
画面下部に体重・体脂肪の入力欄と登録ボタンを配置し、
ボタン押下でデータが保存される仕組みを追加しました。

# 実装内容
- body_records テーブルを使用し、体重・体脂肪・measured_on を保存できるように実装
- 画面下部固定の入力フォームを実装

Closes #34
