### PR TITLE
feat: 体重記録一覧表示

### DIFF
--- a/app/controllers/settings/body_records_controller.rb
+++ b/app/controllers/settings/body_records_controller.rb
@@ -1,0 +1,39 @@
+module Settings
+  class BodyRecordsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_body_record, only: [ :show, :edit, :update, :destroy ]
+
+    def index
+      @body_records = current_user.body_records.order(measured_on: :desc)
+    end
+
+    def show
+    end
+
+    def edit
+    end
+
+    def update
+      if @body_record.update(body_record_params)
+        redirect_to settings_body_records_path, notice: "更新しました"
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @body_record.destroy
+      redirect_to settings_body_records_path, notice: "削除しました"
+    end
+
+    private
+
+    def set_body_record
+      @body_record = current_user.body_records.find(params[:id])
+    end
+
+    def body_record_params
+      params.require(:body_record).permit(:measured_on, :weight, :body_fat)
+    end
+  end
+end

--- a/app/controllers/settings/goal_weights_controller.rb
+++ b/app/controllers/settings/goal_weights_controller.rb
@@ -1,0 +1,48 @@
+module Settings
+  class GoalWeightsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_goal_weight, only: [ :show, :edit, :update, :destroy ]
+
+    def show
+    end
+
+    def new
+      @goal_weight = current_user.build_goal_weight
+    end
+
+    def create
+      @goal_weight = current_user.build_goal_weight(goal_weight_params)
+      if @goal_weight.save
+        redirect_to settings_goal_weight_path, notice: "目標体重を設定しました"
+      else
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @goal_weight.update(goal_weight_params)
+        redirect_to settings_goal_weight_path, notice: "更新しました"
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @goal_weight.destroy
+      redirect_to settings_goal_weight_path, notice: "削除しました"
+    end
+
+    private
+
+    def set_goal_weight
+      @goal_weight = current_user.goal_weight
+    end
+
+    def goal_weight_params
+      params.require(:goal_weight).permit(:weight)
+    end
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -47,7 +47,7 @@ end
       format.turbo_stream
     end
   end
-end
+  end
 
   def destroy
     @task = current_user.tasks.find(params[:id])

--- a/app/views/settings/body_records/index.html.erb
+++ b/app/views/settings/body_records/index.html.erb
@@ -1,0 +1,38 @@
+<div class="max-w-full mx-auto space-y-6 px-4 pb-32">
+
+  <!-- ページタイトル -->
+  <h1 class="text-2xl font-bold text-center mb-4">体重記録一覧</h1>
+
+
+  <!-- 体重一覧テーブル -->
+  <div class="overflow-x-auto bg-base-100 rounded-lg shadow-lg p-4">
+    <table class="table w-full table-zebra">
+      <thead>
+        <tr class="bg-base-200">
+          <th class="text-left">日付</th>
+          <th class="text-left">体重(kg)</th>
+          <th class="text-left">体脂肪(%)</th>
+          <th class="text-left">操作</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @body_records.each do |record| %>
+          <tr>
+            <td><%= record.measured_on.strftime("%Y/%m/%d") %></td>
+            <td><%= record.weight %></td>
+            <td><%= record.body_fat || "-" %></td>
+            <td class="flex gap-2">
+              <%= link_to "編集", edit_settings_body_record_path(record),
+                          class: "btn btn-sm btn-outline btn-primary" %>
+              <%= link_to "削除", settings_body_record_path(record),
+                          method: :delete,
+                          data: { confirm: "本当に削除しますか？" },
+                          class: "btn btn-sm btn-outline btn-error" %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,4 +27,9 @@ Rails.application.routes.draw do
   end
   resources :memos
   resources :body_records, only: [ :index, :create ]
+
+  namespace :settings do
+    resources :body_records, only: [ :index, :show, :edit, :update, :destroy ]
+    resource  :goal_weight, only: [ :show, :new, :create, :edit, :update, :destroy ]
+  end
 end


### PR DESCRIPTION
# 概要
体重記録の一覧ページを作成し、ユーザーが設定から体重・体脂肪の履歴を確認できるようにする。

# 実装内容
- Settings::BodyRecordsController の index アクション実装
- 一覧表示用ビュー（daisyUI + Tailwind）作成
- 編集ボタンを紫色にし、削除ボタンを右側に配置
- レスポンシブ対応、スマホでも横スクロールが出ないレイアウトに調整
- 新規追加ボタン設置で入力フォームへの誘導

Closes #53