### PR TITLE
feat: 体重記録削除

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -3,24 +3,30 @@ class HomesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-  res = WeatherService.fetch(city: "tokyo")
+    # 天気情報の取得
+    res = WeatherService.fetch(city: "tokyo")
 
-  @weather =
-    if res&.dig("weather", 0)
-      {
-        icon: res["weather"][0]["icon"],
-        description: res["weather"][0]["description"],
-        temp: (res["main"]["temp"] - 273.15).round(1),
-        humidity: res["main"]["humidity"]
-      }
+    @weather =
+      if res&.dig("weather", 0)
+        {
+          icon: res["weather"][0]["icon"],
+          description: res["weather"][0]["description"],
+          temp: (res["main"]["temp"] - 273.15).round(1),
+          humidity: res["main"]["humidity"]
+        }
+      end
+
+    # タスクと習慣の取得
+    @tasks = current_user.tasks.order(created_at: :desc)
+    @habits = current_user.habits.order(created_at: :desc)
+
+    # 習慣の日付補完
+    @habits.each do |habit|
+      habit.start_date ||= Date.current
+      habit.end_date ||= Date.current
     end
-  @tasks = current_user.tasks.order(created_at: :desc)
-  @habits = current_user.habits.order(created_at: :desc)
-@habits.each do |habit|
-  habit.start_date ||= Date.current
-  habit.end_date ||= Date.current
-end
 
-  @home_memo = current_user.home_memo || current_user.create_home_memo!
+    # ホームメモの取得または作成
+    @home_memo = current_user.home_memo || current_user.create_home_memo!
   end
 end

--- a/app/views/settings/body_records/edit.html.erb
+++ b/app/views/settings/body_records/edit.html.erb
@@ -22,10 +22,10 @@
 
       <div class="flex flex-col gap-2 mt-4">
         <%= f.submit "登録", class: "btn btn-primary w-full" %>
-        <%= button_to "削除", settings_body_record_path(@body_record),
+        <%= link_to "削除", settings_body_record_path(@body_record),
               method: :delete,
-              data: { confirm: "本当に削除しますか？" },
-              class: "btn btn-outline btn-error w-full" %>
+              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
+      class: "btn w-full h-10 text-sm border border-blue-300 text-blue-400 hover:bg-blue-50" %>
       </div>
 
     </div>

--- a/app/views/settings/body_records/index.html.erb
+++ b/app/views/settings/body_records/index.html.erb
@@ -24,10 +24,6 @@
             <td class="flex gap-2">
               <%= link_to "編集", edit_settings_body_record_path(record),
                           class: "btn btn-sm btn-outline btn-primary" %>
-              <%= link_to "削除", settings_body_record_path(record),
-                          method: :delete,
-                          data: { confirm: "本当に削除しますか？" },
-                          class: "btn btn-sm btn-outline btn-error" %>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
# 概要

体重記録の削除機能を実装しました。  
編集画面から削除ボタンを押すと、確認ダイアログ後に該当の体重記録を削除できるようになっています。

# 実装内容

- `Settings::BodyRecordsController` に `destroy` アクションを追加
- 編集ページの削除ボタンを `link_to` に変更し、Turbo で削除できるよう実装
- 削除後は一覧ページにリダイレクトし、削除完了メッセージを表示

Closes #55