### PR TITLE
feat/growth-record-toggle

### DIFF
--- a/app/controllers/settings/growth_settings/displays_controller.rb
+++ b/app/controllers/settings/growth_settings/displays_controller.rb
@@ -1,0 +1,21 @@
+# クラス名が Settings::GrowthSettings::DisplaysController になる点に注目！
+class Settings::GrowthSettings::DisplaysController < ApplicationController
+  def show
+    @user = current_user
+  end
+
+  def update
+    @user = current_user
+    if @user.update(user_params)
+      redirect_to settings_growth_setting_display_path, notice: "更新しました"
+    else
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:is_growth_record_enabled)
+  end
+end

--- a/app/controllers/settings/growth_settings_controller.rb
+++ b/app/controllers/settings/growth_settings_controller.rb
@@ -1,0 +1,27 @@
+class Settings::GrowthSettingsController < ApplicationController
+  before_action :authenticate_user! # ログインしていない人は見れないようにする
+
+  # 表示設定画面（スイッチがあるページ）
+  def show
+    @user = current_user
+  end
+
+  # スイッチを切り替えた時の保存処理
+  def update
+    @user = current_user
+    if @user.update(user_params)
+      # 保存に成功したら、メッセージと一緒に設定画面に戻る
+      redirect_to settings_growth_setting_path, notice: "表示設定を更新しました"
+    else
+      # 失敗した場合は画面を再表示（基本は失敗しませんが、Railsのルールとして）
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  # 悪意のあるデータが入り込まないように、特定の項目だけ許可する（Strong Parameters）
+  def user_params
+    params.require(:user).permit(:is_growth_record_enabled)
+  end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,54 +1,90 @@
-<h2 class="text-2xl font-bold text-center mb-6 text-gray-800">アカウント情報の編集</h2>
+<div class="max-w-md mx-auto px-4 pt-8 pb-20">
+  <%# 1. 共通ヘッダー：設定トップへ戻る %>
+  <div class="flex items-center mb-6">
+    <%= render 'shared/back_button', path: settings_root_path %>
+    <h1 class="text-xl font-bold flex-1 text-center mr-10 text-gray-700">
+      アカウント設定
+    </h1>
+  </div>
 
-<div class="max-w-sm mx-auto bg-white shadow-xl rounded-xl p-8 space-y-6">
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-5" }) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
-
-    <div>
-      <label class="label">
-        <span class="label-text font-semibold">メールアドレス</span>
-      </label>
-      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered w-full bg-base-200" %>
+  <%# 2. メインカード %>
+  <div class="bg-white rounded-[2rem] p-6 shadow-sm border border-base-200">
+    <div class="flex items-center gap-2 mb-8">
+      <span class="w-1 h-6 bg-primary rounded-full"></span>
+      <h2 class="font-bold text-gray-700 text-lg">登録情報の編集</h2>
     </div>
 
-    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-      <div class="text-sm text-gray-500">
-        現在、確認中のメールアドレス：<%= resource.unconfirmed_email %>
+    <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-6" }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+
+      <%# メールアドレス %>
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text font-bold text-gray-600">メールアドレス</span>
+        </label>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", 
+              class: "input input-bordered w-full rounded-2xl bg-base-50 focus:bg-white transition-all h-12" %>
+      </div>
+
+      <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+        <div class="alert alert-info shadow-sm text-xs rounded-xl">
+          確認待ち: <%= resource.unconfirmed_email %>
+        </div>
+      <% end %>
+
+      <div class="divider text-[10px] text-gray-300">パスワード変更</div>
+
+      <%# 新しいパスワード %>
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text font-bold text-gray-600">新しいパスワード</span>
+          <% if @minimum_password_length %>
+            <span class="label-text-alt text-gray-400"><%= @minimum_password_length %>文字以上</span>
+          <% end %>
+        </label>
+        <%= f.password_field :password, autocomplete: "new-password", placeholder: "変更する場合のみ入力",
+              class: "input input-bordered w-full rounded-2xl bg-base-50 focus:bg-white transition-all h-12" %>
+      </div>
+
+      <%# 確認用パスワード %>
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text font-bold text-gray-600">パスワード再入力</span>
+        </label>
+        <%= f.password_field :password_confirmation, autocomplete: "new-password",
+              class: "input input-bordered w-full rounded-2xl bg-base-50 focus:bg-white transition-all h-12" %>
+      </div>
+
+      <div class="divider text-[10px] text-gray-400 bg-primary/5 py-1 rounded-lg font-bold">保存には現在のパスワードが必要です</div>
+
+      <%# 現在のパスワード（必須項目） %>
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text font-bold text-primary">現在のパスワード</span>
+        </label>
+        <%= f.password_field :current_password, autocomplete: "current-password",
+              class: "input input-bordered border-primary/30 w-full rounded-2xl bg-primary/5 focus:bg-white transition-all h-12" %>
+      </div>
+
+      <%# 更新ボタン %>
+      <div class="pt-4">
+        <%= f.submit "設定を更新する", 
+              class: "btn btn-primary w-full rounded-full text-white shadow-md hover:shadow-lg transition-all h-12 no-animation" %>
       </div>
     <% end %>
+  </div>
 
-    <div>
-      <label class="label">
-        <span class="label-text font-semibold">現在のパスワード</span>
-        <span class="text-xs text-gray-500">(変更を確定するには入力が必要です)</span>
-      </label>
-      <%= f.password_field :current_password, autocomplete: "current-password", class: "input input-bordered w-full bg-base-200" %>
-    </div>
-    <div>
-      <label class="label">
-        <span class="label-text font-semibold">新しいパスワード（任意）</span>
-        <% if @minimum_password_length %>
-          <span class="text-xs text-gray-500">（<%= @minimum_password_length %>文字以上）</span>
-        <% end %>
-      </label>
-      <%= f.password_field :password, autocomplete: "new-password", class: "input input-bordered w-full bg-base-200" %>
-    </div>
-
-    <div>
-      <label class="label">
-        <span class="label-text font-semibold">パスワード確認</span>
-      </label>
-      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "input input-bordered w-full bg-base-200" %>
-    </div>
-
-    <div>
-      <%= f.submit "更新する", class: "btn btn-primary btn-block" %>
-    </div>
-  <% end %>
-
-  <div class="text-center mt-6 space-y-3">
-    <div>
-      <%= link_to "戻る", root_path, class: "link link-hover text-blue-600" %>
-    </div>
+  <%# 3. アカウント削除（退会）の案内 %>
+  <div class="mt-12 px-4">
+    <div class="divider text-xs text-gray-300">退会について</div>
+    <p class="text-[10px] text-gray-400 text-center mb-4 leading-relaxed">
+      退会すると、これまでの記録はすべて削除され、<br>復元することはできません。
+    </p>
+    <%= button_to registration_path(resource_name), 
+          method: :delete, 
+          data: { confirm: "本当に退会しますか？", turbo_confirm: "本当に退会しますか？" },
+          class: "btn btn-ghost btn-sm w-full text-error/50 hover:text-error hover:bg-error/10 transition-all" do %>
+      アカウントを削除して退会する
+    <% end %>
   </div>
 </div>

--- a/app/views/devise/shared/_footer.html.erb
+++ b/app/views/devise/shared/_footer.html.erb
@@ -26,15 +26,17 @@
     <% end %>
 
     <%# 成長記録（ここがお子さまIDが必要な場所） %>
-    <% if current_user.children.any? %>
-      <%= link_to child_growth_records_path(current_user.children.first), class: "flex flex-col items-center p-2 hover:text-pink-500" do %>
-        <%= image_tag "growth_record.png", alt: "growth_record", class: "w-6 h-6 mb-1" %>
-        growth
-      <% end %>
-    <% else %>
-      <%= link_to settings_children_path, class: "flex flex-col items-center p-2 opacity-50" do %>
-        <%= image_tag "growth_record.png", alt: "growth_record", class: "w-6 h-6 mb-1" %>
-        growth
+    <% if current_user.is_growth_record_enabled? %>
+      <% if current_user.children.any? %>
+        <%= link_to child_growth_records_path(current_user.children.first), class: "flex flex-col items-center p-2 hover:text-pink-500" do %>
+          <%= image_tag "growth_record.png", alt: "growth_record", class: "w-6 h-6 mb-1" %>
+          growth
+        <% end %>
+      <% else %>
+        <%= link_to settings_children_path, class: "flex flex-col items-center p-2 opacity-50" do %>
+          <%= image_tag "growth_record.png", alt: "growth_record", class: "w-6 h-6 mb-1" %>
+          growth
+        <% end %>
       <% end %>
     <% end %>
 

--- a/app/views/settings/body_records/edit.html.erb
+++ b/app/views/settings/body_records/edit.html.erb
@@ -1,33 +1,62 @@
-<div class="max-w-md mx-auto px-4 pb-32 space-y-6">
+<div class="max-w-md mx-auto px-4 pt-8 pb-20">
+  <%# 共通ヘッダー：一覧に戻る %>
+  <div class="flex items-center mb-6">
+    <%= render 'shared/back_button', path: settings_body_records_path %>
+    <h1 class="text-xl font-bold flex-1 text-center mr-10 text-gray-700">
+      体重記録の編集
+    </h1>
+  </div>
 
-  <h1 class="text-xl font-bold mb-4">体重記録の編集</h1>
+  <div class="space-y-6">
+    <%= form_with model: @body_record, url: settings_body_record_path(@body_record), local: true do |f| %>
+      <div class="bg-white p-6 rounded-[2rem] shadow-sm border border-base-200 space-y-5">
+        
+        <%# 入力セクション %>
+        <div class="form-control w-full">
+          <label class="label">
+            <span class="label-text font-bold text-gray-600">記録日</span>
+          </label>
+          <%= f.date_field :measured_on, 
+                class: "input input-bordered w-full rounded-2xl bg-base-50 focus:bg-white transition-all" %>
+        </div>
 
-  <%= form_with model: @body_record, url: settings_body_record_path(@body_record), local: true do |f| %>
-    <div class="space-y-4 bg-base-100 p-4 rounded-lg shadow">
+        <div class="grid grid-cols-2 gap-4">
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text font-bold text-gray-600">体重 (kg)</span>
+            </label>
+            <%= f.number_field :weight, step: 0.1, 
+                  class: "input input-bordered w-full rounded-2xl bg-base-50 focus:bg-white transition-all" %>
+          </div>
 
-      <div>
-        <label class="label">日付</label>
-        <%= f.date_field :measured_on, class: "input input-bordered w-full" %>
+          <div class="form-control w-full">
+            <label class="label">
+              <span class="label-text font-bold text-gray-600">体脂肪 (%)</span>
+            </label>
+            <%= f.number_field :body_fat, step: 0.1, 
+                  class: "input input-bordered w-full rounded-2xl bg-base-50 focus:bg-white transition-all" %>
+          </div>
+        </div>
+
+        <%# 保存ボタン %>
+        <div class="pt-4">
+          <%= f.submit "更新する", 
+                class: "btn btn-primary w-full rounded-full text-white shadow-md hover:shadow-lg transition-all h-12" %>
+        </div>
       </div>
+    <% end %>
 
-      <div>
-        <label class="label">体重(kg)</label>
-        <%= f.number_field :weight, step: 0.1, class: "input input-bordered w-full" %>
-      </div>
-
-      <div>
-        <label class="label">体脂肪(%)</label>
-        <%= f.number_field :body_fat, step: 0.1, class: "input input-bordered w-full" %>
-      </div>
-
-      <div class="flex flex-col gap-2 mt-4">
-        <%= f.submit "登録", class: "btn btn-primary w-full" %>
-        <%= link_to "削除", settings_body_record_path(@body_record),
-              method: :delete,
-              data: { turbo_method: :delete, turbo_confirm: "本当に削除しますか？" },
-      class: "btn w-full h-10 text-sm border border-blue-300 text-blue-400 hover:bg-blue-50" %>
-      </div>
-
+    <%# 削除セクション（少し離して配置し、注意を促す） %>
+    <div class="px-4">
+      <div class="divider text-xs text-gray-300">Danger Zone</div>
+      <%= link_to settings_body_record_path(@body_record),
+            data: { turbo_method: :delete, turbo_confirm: "この記録を削除してもよろしいですか？" },
+            class: "btn btn-ghost btn-sm w-full text-error/60 hover:text-error hover:bg-error/10 rounded-xl transition-all" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+        </svg>
+        この記録を削除する
+      <% end %>
     </div>
-  <% end %>
+  </div>
 </div>

--- a/app/views/settings/body_records/index.html.erb
+++ b/app/views/settings/body_records/index.html.erb
@@ -1,34 +1,89 @@
-<div class="max-w-full mx-auto space-y-6 px-4 pb-32">
-
-  <!-- ページタイトル -->
-  <h1 class="text-2xl font-bold text-center mb-4">体重記録一覧</h1>
-
-
-  <!-- 体重一覧テーブル -->
-  <div class="overflow-x-auto bg-base-100 rounded-lg shadow-lg p-4">
-    <table class="table w-full table-zebra">
-      <thead>
-        <tr class="bg-base-200">
-          <th class="text-left">日付</th>
-          <th class="text-left">体重(kg)</th>
-          <th class="text-left">体脂肪(%)</th>
-          <th class="text-left">操作</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% @body_records.each do |record| %>
-          <tr>
-            <td><%= record.measured_on.strftime("%Y/%m/%d") %></td>
-            <td><%= record.weight %></td>
-            <td><%= record.body_fat || "-" %></td>
-            <td class="flex gap-2">
-              <%= link_to "編集", edit_settings_body_record_path(record),
-                          class: "btn btn-sm btn-outline btn-primary" %>
-            </td>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+<div class="max-w-md mx-auto px-4 pt-8 pb-20">
+  <%# 1. ヘッダーエリア %>
+  <div class="flex items-center mb-6">
+    <%= render 'shared/back_button', path: settings_root_path %>
+    <h1 class="text-xl font-bold flex-1 text-center mr-10 text-gray-700">
+      体重記録管理
+    </h1>
   </div>
 
+  <div class="space-y-6">
+    <%# 2. メインカード %>
+    <div class="bg-white rounded-[2rem] p-6 shadow-sm border border-base-200">
+      
+      <%# カード内の見出し %>
+      <div class="flex items-center justify-between mb-6">
+        <div class="flex items-center gap-2">
+          <span class="w-1 h-6 bg-primary rounded-full"></span>
+          <h2 class="font-bold text-gray-700 text-lg">過去の記録</h2>
+        </div>
+        <span class="badge badge-ghost font-mono text-xs"><%= @body_records.count %> 件</span>
+      </div>
+
+      <%# 3. 記録リスト部分 %>
+      <div class="space-y-4">
+        <% if @body_records.any? %>
+          <% @body_records.each do |record| %>
+            <div class="p-4 bg-base-50 border border-base-100 rounded-2xl">
+              
+              <%# 日付ラベル（区切り線付き） %>
+              <div class="text-[10px] font-bold text-gray-400 mb-3 flex items-center gap-2">
+                <span class="bg-white px-2 py-0.5 rounded-md border border-base-200">
+                  <%= record.measured_on.strftime("%Y/%m/%d") %>
+                </span>
+                <div class="h-px flex-1 bg-gray-200"></div>
+              </div>
+
+              <div class="flex items-center justify-between">
+                <%# 数値表示エリア（幅を固定して縦のラインを揃える） %>
+                <div class="flex items-center">
+                  
+                  <%# 体重カラム %>
+                  <div class="w-24 flex flex-col">
+                    <span class="text-[10px] font-bold text-gray-400 mb-0.5">体重</span>
+                    <div class="flex items-baseline gap-0.5">
+                      <span class="text-xl font-black text-gray-700">
+                        <%= record.weight %>
+                      </span>
+                      <span class="text-[10px] font-bold text-gray-500">kg</span>
+                    </div>
+                  </div>
+
+                  <%# 体脂肪カラム（境界線付き） %>
+                  <div class="w-24 flex flex-col border-l border-gray-200 pl-4">
+                    <span class="text-[10px] font-bold text-gray-400 mb-0.5">体脂肪</span>
+                    <div class="flex items-baseline gap-0.5">
+                      <% if record.body_fat.present? %>
+                        <span class="text-xl font-black text-gray-700">
+                          <%= record.body_fat %>
+                        </span>
+                        <span class="text-[10px] font-bold text-gray-500">%</span>
+                      <% else %>
+                        <span class="text-xl font-black text-gray-200">--</span>
+                        <span class="text-[10px] font-bold text-gray-300">%</span>
+                      <% end %>
+                    </div>
+                  </div>
+                </div>
+
+                <%# 操作ボタン %>
+                <%= link_to edit_settings_body_record_path(record), 
+                      class: "btn btn-ghost btn-circle btn-sm text-primary hover:bg-primary/10 transition-colors" do %>
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+                  </svg>
+                <% end %>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <%# 記録がない場合の表示 %>
+          <div class="text-center py-12 bg-base-50 rounded-2xl border border-dashed border-base-300">
+            <p class="text-sm text-gray-400 italic">まだ記録がありません</p>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+  </div>
 </div>

--- a/app/views/settings/children/_form.html.erb
+++ b/app/views/settings/children/_form.html.erb
@@ -42,9 +42,4 @@
     </div>
   <% end %>
 
-  <%# 戻るボタン %>
-  <div class="text-center">
-    <%= link_to "一覧に戻る", settings_children_path, 
-          class: "text-sm text-gray-400 underline underline-offset-4" %>
-  </div>
 </div>

--- a/app/views/settings/children/edit.html.erb
+++ b/app/views/settings/children/edit.html.erb
@@ -1,9 +1,19 @@
-<div class="py-8">
-  <div class="text-center mb-10">
-    <h1 class="text-xl font-bold">成長記録設定</h1>
-    <p class="text-sm opacity-60">お子さま情報編集</p>
+<div class="max-w-md mx-auto px-4 pt-8 pb-20">
+  <%# 共通ヘッダー：お子さま一覧に戻る %>
+  <div class="flex items-center mb-6">
+    <%= render 'shared/back_button', path: settings_children_path %>
+    <h1 class="text-xl font-bold flex-1 text-center mr-10 text-gray-700">
+      お子さま情報の編集
+    </h1>
   </div>
 
-  <%# 共通のフォーム部品を呼び出し %>
-  <%= render 'form', child: @child %>
+  <div class="bg-white rounded-[2rem] p-6 shadow-sm border border-base-200">
+    <div class="flex items-center gap-2 mb-8">
+      <span class="w-1 h-6 bg-primary rounded-full"></span>
+      <h2 class="font-bold text-gray-700 text-lg">情報の入力</h2>
+    </div>
+
+    <%# フォーム本体を呼び出し %>
+    <%= render 'form', child: @child %>
+  </div>
 </div>

--- a/app/views/settings/children/index.html.erb
+++ b/app/views/settings/children/index.html.erb
@@ -1,9 +1,12 @@
 <div class="max-w-md mx-auto px-4 pt-8 pb-20">
-  <%# ヘッダー %>
-  <h1 class="text-xl font-bold text-center mb-8">成長記録設定</h1>
+  <%# ヘッダー（戻るボタンを追加） %>
+  <div class="flex items-center mb-6">
+    <%= render 'shared/back_button', title: 'お子さま管理', path: settings_growth_setting_path %>
+    <h1 class="text-xl font-bold flex-1 text-center mr-10 text-gray-700">お子さま管理</h1>
+  </div>
   
   <div class="bg-base-100 rounded-3xl p-6 shadow-sm border border-base-200">
-    <h2 class="text-lg font-bold mb-6 flex items-center gap-2">
+    <h2 class="text-lg font-bold mb-6 flex items-center gap-2 text-gray-700">
       <span class="w-1 h-6 bg-primary rounded-full"></span>
       お子さま一覧
     </h2>
@@ -28,7 +31,6 @@
           <% end %>
         <% end %>
       <% else %>
-        <%# 登録がない時の表示 %>
         <div class="text-center py-10">
           <p class="text-sm text-gray-400">まだ登録されている<br>お子さまがいません</p>
         </div>
@@ -38,7 +40,7 @@
     <%# お子さま追加ボタン %>
     <div class="mt-10">
       <%= link_to new_settings_child_path, 
-            class: "btn btn-primary w-full rounded-full text-white shadow-lg gap-2" do %>
+            class: "btn btn-primary shadow-xl brightness-95 hover:brightness-90 w-full rounded-full text-white shadow-lg gap-2" do %>
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
         </svg>
@@ -47,8 +49,4 @@
     </div>
   </div>
 
-  <%# 設定トップへ戻る %>
-  <div class="mt-8 text-center">
-    <%= link_to "設定に戻る", settings_root_path, class: "text-sm text-gray-400 underline underline-offset-4" %>
-  </div>
 </div>

--- a/app/views/settings/children/new.html.erb
+++ b/app/views/settings/children/new.html.erb
@@ -1,6 +1,19 @@
-<div class="py-8">
-  <h1 class="text-xl font-bold text-center mb-10">お子さま追加登録</h1>
+<div class="max-w-md mx-auto px-4 pt-8 pb-20">
+  <%# 共通ヘッダー：お子さま一覧に戻る %>
+  <div class="flex items-center mb-6">
+    <%= render 'shared/back_button', path: settings_children_path %>
+    <h1 class="text-xl font-bold flex-1 text-center mr-10 text-gray-700">
+      お子さま情報の編集
+    </h1>
+  </div>
 
-  <%# render で部品を呼び出し、@child を child という変数として渡す %>
-  <%= render 'form', child: @child %>
+  <div class="bg-white rounded-[2rem] p-6 shadow-sm border border-base-200">
+    <div class="flex items-center gap-2 mb-8">
+      <span class="w-1 h-6 bg-primary rounded-full"></span>
+      <h2 class="font-bold text-gray-700 text-lg">情報の入力</h2>
+    </div>
+
+    <%# フォーム本体を呼び出し %>
+    <%= render 'form', child: @child %>
+  </div>
 </div>

--- a/app/views/settings/dashboards/show.html.erb
+++ b/app/views/settings/dashboards/show.html.erb
@@ -25,16 +25,16 @@
       <% end %>
 
       <%= link_to settings_growth_setting_path,
-            class: "btn btn-outline w-full justify-between" do %>
-        <span>成長記録表示設定</span>
-        <span>›</span>
-      <% end %>
-
-      <%= link_to settings_children_path,
-            class: "btn btn-outline w-full justify-between" do %>
-        <span>お子さま管理</span>
-        <span>›</span>
-      <% end %>
+      class: "btn btn-outline w-full justify-between" do %>
+  <span>成長記録設定</span>
+  <div class="flex items-center gap-2">
+    <%# 現在の状態がパッとわかるようにバッジを添えると親切です %>
+    <span class="badge badge-sm <%= current_user.is_growth_record_enabled? ? 'badge-primary' : 'badge-ghost' %>">
+      <%= current_user.is_growth_record_enabled? ? "ON" : "OFF" %>
+    </span>
+    <span>›</span>
+  </div>
+<% end %>
 
       <%= link_to edit_user_registration_path,
             class: "btn btn-outline w-full justify-between" do %>

--- a/app/views/settings/growth_settings/displays/show.html.erb
+++ b/app/views/settings/growth_settings/displays/show.html.erb
@@ -1,0 +1,40 @@
+<div class="max-w-md mx-auto mt-8 px-4 pb-20">
+  
+  <%# ヘッダーエリア %>
+  <div class="flex items-center mb-8">
+    <%= render "shared/back_button", path: settings_growth_setting_path %>
+    <h1 class="text-xl font-bold flex-1 text-center mr-10 text-gray-700">成長記録表示設定</h1>
+  </div>
+
+  <%# 設定カード %>
+  <div class="bg-white rounded-[2rem] p-8 shadow-sm border border-base-200">
+    <div class="flex flex-col items-center text-center space-y-6">
+      
+      <%# アイコン表示 %>
+
+      <div class="space-y-2">
+        <h2 class="text-lg font-bold text-gray-700">成長記録機能</h2>
+        <p class="text-sm text-gray-400 leading-relaxed">
+          「成長記録」を表示するかどうかを選択できます。
+        </p>
+      </div>
+
+      <%# 設定フォーム %>
+      <%= form_with model: @user, url: settings_growth_setting_path, method: :patch, local: true, class: "w-full" do |f| %>
+  <div class="form-control">
+    <label class="label cursor-pointer p-5 bg-base-50 rounded-2xl border border-base-200">
+      <span class="label-text font-bold text-gray-600">メニューに表示する</span>
+      <%= f.check_box :is_growth_record_enabled, 
+            class: "toggle toggle-primary toggle-lg", 
+            onchange: "this.form.requestSubmit();" %>
+    </label>
+  </div>
+<% end %>
+
+      <p class="text-[10px] text-gray-400">
+        ※オフにしても過去の記録が消えることはありません。<br>
+        いつでも再度オンに戻せます。
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/settings/growth_settings/show.html.erb
+++ b/app/views/settings/growth_settings/show.html.erb
@@ -1,0 +1,37 @@
+<div class="max-w-md mx-auto mt-8 px-4">
+  <div class="flex items-center mb-6">
+    <%# 戻り先は設定のトップ %>
+    <%= render 'shared/back_button', path: settings_root_path %>
+    <h1 class="text-2xl font-bold flex-1 text-center mr-10">
+      成長記録設定
+    </h1>
+  </div>
+
+  <div class="card bg-base-100 shadow-md">
+    <div class="card-body p-4 space-y-3">
+
+      <%# 子要素1：表示設定ページへ %>
+      <%= link_to settings_growth_setting_display_path,
+            class: "btn btn-outline w-full justify-between" do %>
+        <span>成長記録表示設定</span>
+        <span>›</span>
+      <% end %>
+
+      <%# 子要素2：お子さま管理ページへ %>
+      <%= link_to settings_children_path,
+            class: "btn btn-outline w-full justify-between" do %>
+        <span>お子さま管理</span>
+        <span>›</span>
+      <% end %>
+
+    </div>
+  </div>
+
+  <div class="mt-8 px-4">
+    <p class="text-xs text-gray-400 text-center leading-relaxed">
+      成長記録機能のON/OFFや、<br>
+      記録対象のお子さま情報の編集ができます。
+    </p>
+  </div>
+</div>
+

--- a/app/views/settings/weight_goals/index.html.erb
+++ b/app/views/settings/weight_goals/index.html.erb
@@ -1,52 +1,66 @@
-<div class="max-w-md mx-auto px-4 pb-32 space-y-6">
-
-  <h1 class="text-xl font-bold mb-4">
-    目標体重の設定
-  </h1>
-
-  <!-- 現在の目標表示 -->
-  <div class="bg-base-100 p-4 rounded-lg shadow">
-    <p class="text-sm text-gray-500 mb-1">現在の目標</p>
-
-    <% latest_goal = current_user.weight_goals.latest_first.first %>
-
-    <% if latest_goal.present? %>
-      <p class="text-lg font-semibold">
-        <%= latest_goal.target_weight %> kg
-      </p>
-      <p class="text-sm text-gray-500">
-        期限：<%= latest_goal.target_date %>
-      </p>
-    <% else %>
-      <p class="text-lg font-semibold text-gray-400">
-        ーー
-      </p>
-    <% end %>
+<div class="max-w-md mx-auto px-4 pt-8 pb-20">
+  <%# 共通ヘッダー：設定トップに戻る %>
+  <div class="flex items-center mb-6">
+    <%= render 'shared/back_button', path: settings_root_path %>
+    <h1 class="text-xl font-bold flex-1 text-center mr-10 text-gray-700">
+      目標体重の設定
+    </h1>
   </div>
 
-  <%= form_with model: [:settings, @weight_goal], local: true do |f| %>
-
-    <div class="space-y-4 bg-base-100 p-4 rounded-lg shadow">
-
-      <div>
-        <label class="label">目標体重(kg)</label>
-        <%= f.number_field :target_weight,
-              step: 0.1,
-              class: "input input-bordered w-full" %>
+  <div class="space-y-6">
+    <div class="bg-white p-6 rounded-[2rem] shadow-sm border border-base-200">
+      <div class="flex items-center gap-2 mb-4">
+        <span class="w-1 h-6 bg-secondary rounded-full"></span>
+        <h2 class="font-bold text-gray-700">現在の目標</h2>
       </div>
 
-      <div>
-        <label class="label">目標日</label>
-        <%= f.date_field :target_date,
-              class: "input input-bordered w-full" %>
-      </div>
+      <% latest_goal = current_user.weight_goals.latest_first.first %>
 
-      <div class="flex flex-col gap-2 mt-4">
-        <%= f.submit "保存",
-              class: "btn btn-primary w-full h-10 text-base" %>
+      <div class="flex flex-col items-center py-2">
+        <% if latest_goal.present? %>
+          <div class="flex items-baseline gap-1">
+            <span class="text-4xl font-black text-secondary"><%= latest_goal.target_weight %></span>
+            <span class="text-sm font-bold text-gray-500">kg</span>
+          </div>
+          <p class="text-xs text-gray-400 mt-2 bg-base-100 px-3 py-1 rounded-full">
+            期限：<%= latest_goal.target_date %>
+          </p>
+        <% else %>
+          <p class="text-lg font-bold text-gray-300 py-4">未設定</p>
+        <% end %>
       </div>
-
     </div>
-  <% end %>
 
+    <%= form_with model: [:settings, @weight_goal], local: true do |f| %>
+      <div class="bg-white p-6 rounded-[2rem] shadow-sm border border-base-200 space-y-5">
+        <div class="flex items-center gap-2 mb-2">
+          <span class="w-1 h-6 bg-primary rounded-full"></span>
+          <h2 class="font-bold text-gray-700">新しい目標を入力</h2>
+        </div>
+
+        <div class="form-control w-full">
+          <label class="label">
+            <span class="label-text font-bold text-gray-600">目標体重 (kg)</span>
+          </label>
+          <%= f.number_field :target_weight,
+                step: 0.1,
+                placeholder: "50.0",
+                class: "input input-bordered w-full rounded-2xl bg-base-50 focus:bg-white transition-all" %>
+        </div>
+
+        <div class="form-control w-full">
+          <label class="label">
+            <span class="label-text font-bold text-gray-600">いつまでに？</span>
+          </label>
+          <%= f.date_field :target_date,
+                class: "input input-bordered w-full rounded-2xl bg-base-50 focus:bg-white transition-all" %>
+        </div>
+
+        <div class="pt-4">
+          <%= f.submit "目標を保存する",
+                class: "btn btn-primary w-full rounded-full text-white shadow-md hover:shadow-lg transition-all" %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/shared/_back_button.html.erb
+++ b/app/views/shared/_back_button.html.erb
@@ -1,0 +1,12 @@
+<%= link_to path, class: "btn btn-ghost btn-circle text-gray-400" do %>
+  <svg xmlns="http://www.w3.org/2000/svg"
+       class="h-6 w-6"
+       fill="none"
+       viewBox="0 0 24 24"
+       stroke="currentColor">
+    <path stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M15 19l-7-7 7-7" />
+  </svg>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,9 @@ Rails.application.routes.draw do
     root "dashboards#show"
     resources :body_records, only: [ :index, :show, :edit, :update, :destroy ]
     resources :weight_goals, only: [ :index, :create ]
-    resource :growth_setting, only: [ :show, :update ]
+    resource :growth_setting, only: [ :show, :update ] do
+      resource :display, only: [ :show, :update ], module: :growth_settings
+    end
     resources :children
     resource :theme_setting
     resource :account_setting

--- a/db/migrate/20260218052651_add_is_growth_record_enabled_to_users.rb
+++ b/db/migrate/20260218052651_add_is_growth_record_enabled_to_users.rb
@@ -1,0 +1,5 @@
+class AddIsGrowthRecordEnabledToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :is_growth_record_enabled, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_17_130317) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_18_052651) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -100,6 +100,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_17_130317) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.boolean "is_growth_record_enabled", default: true, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
# 概要
成長記録のON/OFF切り替え機能の実装と、設定画面全体のUIデザイン刷新を行いました。

# 実装内容
- **成長記録設定の中継ページ追加**: 設定項目を整理しアクセス性を向上
- **表示ON/OFF切り替え**: 機能の有効/無効化を実装
- **共通パーツ化**: 戻るボタンをパーシャル化し、全ページでナビゲーションを統一
- **UI刷新**: 各設定画面をカード形式のデザインへ統一し、視認性を改善

Closes #44