### PR TITLE
feat:習慣に対してのバディの設定

### DIFF
--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -2,22 +2,24 @@
 class HomesController < ApplicationController
   before_action :authenticate_user!
 
-  def index
-    # タスクと習慣の取得
-    @tasks = current_user.tasks.order(created_at: :desc)
-    @habits = current_user.habits.order(created_at: :desc)
+# app/controllers/homes_controller.rb
+def index
+  # 先にデータを全部ロードする
+  @tasks = current_user.tasks.order(created_at: :desc)
+  @habits = current_user.habits.order(created_at: :desc)
 
-    # 習慣の日付補完
-    @habits.each do |habit|
-      habit.start_date ||= Date.current
-      habit.end_date ||= Date.current
-    end
+  # (日付補完などの処理...)
+  @habits.each do |habit|
+    habit.start_date ||= Date.current
+    habit.end_date ||= Date.current
+  end
 
-    # ホームメモの取得または作成
-    @home_memo = current_user.home_memo || current_user.create_home_memo!
-    @latest_goal = current_user.weight_goals.latest_first.first
-    @latest_body_record = current_user.body_records.latest_first.first
+  @home_memo = current_user.home_memo || current_user.create_home_memo!
+  @latest_goal = current_user.weight_goals.order(created_at: :desc).first
+  @latest_body_record = current_user.body_records.order(created_at: :desc).first
 
-    @message = current_user.buddy_message
+  # ★重要：データの準備がすべて終わった「後」にメッセージを作る
+  # さらに .reload をつけて最新のDB状態を強制的に読み込ませる
+  @message = current_user.reload.buddy_message
 end
 end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -21,7 +21,24 @@ class Habit < ApplicationRecord
     end
   end
 
+  # 今日の分が完了しているか
   def checked_today?
     habit_checks.exists?(check_date: Date.current)
+  end
+
+  # 現在の継続日数を計算
+  def current_streak
+    count = 0
+    date = Date.current
+
+    # 今日チェックがない場合は、昨日から遡ってカウント
+    date = date.yesterday unless checked_today?
+
+    # 遡って連続している間だけカウントを増やす
+    while habit_checks.exists?(check_date: date)
+      count += 1
+      date = date.yesterday
+    end
+    count
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,20 +17,33 @@ class User < ApplicationRecord
     weight_goals.order(created_at: :desc).first
   end
 
-  # バディのメッセージを生成するルール
-  def buddy_message
-  # 「今日」の制限を外して、未完了のタスクが残っているかチェック
-  # (まだ終わっていないタスクが一つもなければ all_done)
-  incomplete_tasks = tasks.where(is_done: false)
+# バディのメッセージを生成するルール
+# app/models/user.rb
 
-  # タスクが1つ以上あって、かつ未完了が0個なら「全部完了！」
-  all_done = tasks.present? && incomplete_tasks.empty?
-  if all_done
-    "#{nickname}さん、すごいです！今日のTODOが全部終わってますね！そんなに頑張るなんて、感動しちゃいました。今夜はゆっくり自分を甘やかしてくださいね✨"
-  elsif childcare_mode
-    "#{nickname}さん、今日もお子さんのこと、一生懸命でしたね。本当にお疲れ様。無理だけはしないでくださいね。"
+# app/models/user.rb
+
+# app/models/user.rb
+
+def buddy_message
+  # DBから最新の数を直接取得
+  incomplete_count = tasks.where(is_done: false).count
+  done_habits_count = habits.joins(:habit_checks).where(habit_checks: { check_date: Date.current }).count
+  total_habits_count = habits.count
+
+  all_todos_done = tasks.exists? && incomplete_count == 0
+  all_habits_done = total_habits_count > 0 && (done_habits_count == total_habits_count)
+
+  # 判定ロジック
+  if all_todos_done && all_habits_done
+    "#{nickname}さん、完璧すぎて眩しいです…！TODOも習慣も全部クリア！今日はもう自分を甘やかして✨"
+  elsif all_habits_done
+    "今日の習慣はコンプリートですね！さすがです。残りのTODO（あと#{incomplete_count}個）も応援してます！"
+  elsif done_habits_count > 0
+    "お、習慣を #{done_habits_count} つクリアしましたね！#{nickname}さんの努力、ちゃんと見てますよ。"
+  elsif all_todos_done
+    "TODO完了、お見事です！あとは習慣のチェックだけ。スッキリ終わらせちゃいましょう！"
   else
-    "#{nickname}さん、自分のペースで大丈夫ですよ。今日はどんな一日でしたか？一歩ずつ進んでいきましょう。"
+    "自分のペースで大丈夫ですよ。今はTODOが#{incomplete_count}個残っていますね。"
   end
 end
 end

--- a/app/views/habits/toggle_check.turbo_stream.erb
+++ b/app/views/habits/toggle_check.turbo_stream.erb
@@ -1,6 +1,11 @@
-<%# サーバーから「このIDの要素をこの中身で丸ごと差し替えろ」と指示を出す %>
+<%# app/views/habits/toggle_check.turbo_stream.erb %>
+
+<%# 1. 習慣アイテムの更新 %>
 <%= turbo_stream.replace "habit_#{@habit.id}" do %>
   <div id="habit_<%= @habit.id %>">
     <%= render "habits/habit_item", habit: @habit %>
   </div>
 <% end %>
+
+<%# 2. 更新（命令パーツを呼び出す） %>
+<%= render "homes/update_buddy" %>

--- a/app/views/homes/_update_buddy.turbo_stream.erb
+++ b/app/views/homes/_update_buddy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "buddy_message_area" do %>
+  <%= render "homes/buddy_message", message: current_user.reload.buddy_message %>
+<% end %>

--- a/app/views/tasks/create.turbo_stream.erb
+++ b/app/views/tasks/create.turbo_stream.erb
@@ -6,5 +6,5 @@
       partial: "tasks/edit",          # 編集用のパーシャルを使うことで編集モードで表示
       locals: { task: @task }       # controllerで作った @task を渡す
 %>
-
+<%= render "homes/update_buddy" %>
 

--- a/app/views/tasks/destroy.turbo_stream.erb
+++ b/app/views/tasks/destroy.turbo_stream.erb
@@ -1,1 +1,2 @@
 <%= turbo_stream.remove "task_#{@task.id}" %>
+<%= render "homes/update_buddy" %>

--- a/app/views/tasks/update.turbo_stream.erb
+++ b/app/views/tasks/update.turbo_stream.erb
@@ -7,3 +7,4 @@
         partial: "tasks/task",
         locals: { task: @task } %>
 <% end %>
+<%= render "homes/update_buddy" %>


### PR DESCRIPTION
# 概要
習慣の完了状態や継続日数に応じて、バディがホーム画面で適切なメッセージを返却するロジックを実装しました。また、操作時にリアルタイムでメッセージが更新されるようTurbo Streamに対応させました。

# 実装内容
- Habitモデルへのchecked_today?およびcurrent_streakメソッドの追加
- Userモデルのbuddy_messageメソッドへの習慣判定ロジックの統合
- 習慣のチェック操作に連動してメッセージエリアを更新するTurbo Streamの実装


Closes #130