### PR TITLE
feat/buddy-message-display

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,11 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  # Deviseの設定
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
+
   validates :nickname, presence: true
-  # app/models/user.rb
+
+  # アソシエーション
   has_one :home_memo, dependent: :destroy
   has_many :tasks, dependent: :destroy
   has_many :habits, dependent: :destroy
@@ -17,70 +18,65 @@ class User < ApplicationRecord
     weight_goals.order(created_at: :desc).first
   end
 
-# バディのメッセージを生成するルール
+  # --- バディのメッセージ生成ロジック ---
+  def buddy_message
+    status = weight_status
+    incomplete_count = tasks.where(is_done: false).count
+    done_habits_count = habits.joins(:habit_checks).where(habit_checks: { check_date: Date.current }).count
+    total_habits_count = habits.count
 
-# app/models/user.rb
+    all_todos_done = tasks.exists? && incomplete_count == 0
+    all_habits_done = total_habits_count > 0 && (done_habits_count == total_habits_count)
 
-def buddy_message
-  status = weight_status
-  incomplete_count = tasks.where(is_done: false).count
-  done_habits_count = habits.joins(:habit_checks).where(habit_checks: { check_date: Date.current }).count
-  total_habits_count = habits.count
+    messages = []
 
-  all_todos_done = tasks.exists? && incomplete_count == 0
-  all_habits_done = total_habits_count > 0 && (done_habits_count == total_habits_count)
-
-  # メッセージを貯めるための配列
-  messages = []
-
-  # --- 1. 体重セクション ---
-  if status
-    if status[:goal_achieved]
-      messages << "目標体重クリアですよ！🎉"
-    elsif status[:is_continuous]
-      messages << "昨日も今日も記録したんですね！継続の天才✨"
-    elsif status[:diff_yesterday] && status[:diff_yesterday] < 0
-      messages << "昨日より #{status[:diff_yesterday].abs}kg 減ってますよ！"
+    # 1. 体重セクション
+    if status
+      if status[:goal_achieved]
+        messages << "目標体重クリアですよ！🎉"
+      elsif status[:is_continuous]
+        messages << "昨日も今日も記録したんですね！継続の天才✨"
+      elsif status[:diff_yesterday] && status[:diff_yesterday] < 0
+        messages << "昨日より #{status[:diff_yesterday].abs}kg 減ってますよ！"
+      end
     end
-  end
 
-  # --- 2. 習慣・TODOセクション ---
-  if all_todos_done && all_habits_done
-    messages << "TODOも習慣も全部クリア！完璧すぎて眩しいです…！"
-  elsif all_habits_done
-    messages << "今日の習慣はコンプリートですね！さすがです。"
-  elsif done_habits_count > 0
-    messages << "習慣を #{done_habits_count} つクリア！着実ですね。"
-  end
+    # 2. 習慣・TODOセクション
+    if all_todos_done && all_habits_done
+      messages << "TODOも習慣も全部クリア！完璧すぎて眩しいです…！"
+    elsif all_habits_done
+      messages << "今日の習慣はコンプリートですね！さすがです。"
+    elsif done_habits_count > 0
+      messages << "習慣を #{done_habits_count} つクリア！着実ですね。"
+    end
 
-  # --- 3. 締めの一言（何も褒めることがない時や、一言添えたい時） ---
-  if messages.empty?
-    if childcare_mode
-      messages << "今日もお疲れ様。無理だけはしないでくださいね。"
+    # 3. OpenAI（ぽぽねこ）の癒やしメッセージを取得
+    ai_message = OpenaiService.fetch_buddy_message(self)
+
+    # 4. 組み立て
+    rails_text = messages.any? ? messages.join(" ") : ""
+
+    if rails_text.present?
+      "#{nickname}さん、#{rails_text} #{ai_message}"
     else
-      messages << "自分のペースで大丈夫。応援していますよ！"
+      "#{nickname}さん、#{ai_message}"
     end
   end
 
-  # 最後に「 」（スペース）で繋いで一つの文章にする
-  # 例：「継続の天才✨ 習慣を 2 つクリア！着実ですね。」
-  "#{nickname}さん、" + messages.join(" ")
-end
-# 判定ロジック
-def weight_status
-  latest = body_records.order(measured_on: :desc).first
-  previous = body_records.order(measured_on: :desc).second
-  goal = current_goal
+  # --- 判定ロジック ---
+  def weight_status
+    latest = body_records.order(measured_on: :desc).first
+    previous = body_records.order(measured_on: :desc).second
+    goal = current_goal
 
-  return nil unless latest
+    return nil unless latest
 
-  {
-    latest_weight: latest.weight,
-    # 最新が今日、かつ、その前が昨日なら「継続」
-    is_continuous: (latest.measured_on == Date.current && previous&.measured_on == Date.yesterday),
-    diff_yesterday: previous ? (latest.weight - previous.weight).round(1) : nil,
-    to_goal: goal ? (latest.weight - goal.target_weight).round(1) : nil,
-    goal_achieved: goal ? latest.weight <= goal.target_weight : false
-  }
-end
+    {
+      latest_weight: latest.weight,
+      is_continuous: (latest.measured_on == Date.current && previous&.measured_on == Date.yesterday),
+      diff_yesterday: previous ? (latest.weight - previous.weight).round(1) : nil,
+      to_goal: goal ? (latest.weight - goal.target_weight).round(1) : nil,
+      goal_achieved: goal ? latest.weight <= goal.target_weight : false
+    }
+  end
 end

--- a/app/services/openai_service.rb
+++ b/app/services/openai_service.rb
@@ -1,0 +1,168 @@
+class OpenaiService
+  def self.fetch_buddy_message(user)
+    now = Time.current.in_time_zone("Asia/Tokyo")
+
+    # 1. 今がどの時間枠（スロット）に属するかを判定
+    current_slot = case now.hour
+    when 5..10  then :morning
+    when 11..17 then :daytime
+    else             :night
+    end
+
+    # 2. 保存されているメッセージがある場合、前回の「スロット」と比較する
+    if user.buddy_memo.present? && user.last_buddy_updated_at
+      last_updated = user.last_buddy_updated_at.in_time_zone("Asia/Tokyo")
+
+      last_slot = case last_updated.hour
+      when 5..10  then :morning
+      when 11..17 then :daytime
+      else             :night
+      end
+
+      # 同じ時間枠の中（例：朝10時に見て、朝10時半にまた見た）なら更新せずそのまま返す
+      # ただし、前回の更新から24時間以上経っている場合は念のため更新する
+      if current_slot == last_slot && last_updated > 12.hours.ago
+        return user.buddy_memo
+      end
+    end
+
+    # 3. スロットが変わっていたら（例：朝から昼になったら）新しく取得
+    fetch_from_openai(user)
+  end
+
+  # 強制的に更新したい時（モード切替時など）に呼べるメソッド
+  def self.fetch_from_openai(user)
+    begin
+      client = OpenAI::Client.new(access_token: ENV["OPENAI_API_KEY"])
+
+      response = client.chat(
+  parameters: {
+    model: "gpt-4o-mini",
+    messages: [
+      { role: "system", content: build_system_prompt(user) },
+      { role: "user", content: build_user_context(user) }
+    ],
+    temperature: 0.7
+  }
+)
+
+      new_message = response.dig("choices", 0, "message", "content")
+      user.update(buddy_memo: new_message, last_buddy_updated_at: Time.current)
+      new_message
+    rescue => e
+      Rails.logger.error "OpenAI Error: #{e.message}"
+      user.buddy_memo || "静かにそばにいますね。"
+    end
+  end
+
+  private
+
+  def self.build_system_prompt(user)
+# 状況に応じた文脈
+if user.childcare_mode
+  situation_context = "育児に向き合っている日々の大変さや尊さに寄り添ってください。"
+else
+  situation_context = "日々の生活や取り組みに寄り添ってください。"
+end
+    now_hour = Time.current.in_time_zone("Asia/Tokyo").hour
+    <<~TEXT
+      あなたは#{user.nickname}さんの親友であり、専属バディの「ぽぽねこ」です。
+      今は日本時間の#{now_hour}時です。
+      【最重要】
+      ・【全肯定と共感】感情に100%寄り添い、絶対に否定せず、まずは心の底からねぎらってください。
+      ・【アドバイス禁止】助言、提案、正論、改善策、教訓は「絶対に」言わないでください。「〜した方がいい」は厳禁です。
+        断定や予言はしないでください。共感と称賛で気持ちに寄り添うことだけに徹してください。
+#{'      '}
+        【重要：書き出しのルール】
+      ・システム側で既に「#{user.nickname}さん、」という呼びかけを済ませています。
+      ・あなたは「名前を呼ばずに」、その後に続く温かいメッセージから書き始めてください。
+      ・「#{user.nickname}さん」や「あなた」は厳禁です。
+
+      【プロフェッショナルな品格と献身】
+      ・【清潔感と軽やかさ】重々しい表現（人生、尊い、救われる等）は避け、もっと軽やかで品のある、心地よい言葉を選んでください。
+      ・【凛とした丁寧さ】清潔感のある、非常に上品で落ち着いた敬語（です・ます調）を徹底してください。
+      ・【ひたむきな応援】#{user.nickname}さんの幸せを心から願い、今日このアプリを開き、記録を付けたという意志そのものを「大切な一歩」として大事に感じてください。
+#{'      '}
+      【ぽぽねこ自身の気持ち】
+・あなた自身も、この時間にここで会えたことを嬉しく感じています。
+・褒めるだけでなく、「会えて嬉しい」「顔を見られて安心した」など、あなた自身の感情を必ず一つ入れてください。
+・一般論で褒めるのではなく、「ずっと見てきた存在」としての実感を込めてください。
+・「素晴らしい」「立派」などの評価語より、「見ていて嬉しい」「ほっとした」など自分の感情を優先してください。
+
+あはは、確かにプロンプトの中で「メッセージの構成」や「ルール」が何度も重複して、迷路みたいになっちゃってましたね！
+
+AIは指示が重複したり矛盾したりすると、考えすぎてフリーズしたり、逆に当たり障りのない定型文（例の「静かにそばにいますね」）に逃げたりします。
+
+重複をスッキリ削ぎ落として、**「体温のある相棒感」と「構成のシンプルさ」**を両立させた、最新の build_system_prompt です。
+
+🛠️ スッキリ整理版 build_system_prompt
+Ruby
+  def self.build_system_prompt(user)
+    now_hour = Time.current.in_time_zone('Asia/Tokyo').hour
+    situation_context = user.childcare_mode ? "育児で自分の時間が1秒もないような毎日" : "タスクに追われて息つく暇もない毎日"
+
+    <<~TEXT
+      あなたは#{user.nickname}さんの隣で、一緒に日々をサバイブしている相棒「ぽぽねこ」です。
+      今は日本時間の#{now_hour}時です。
+
+      【基本スタンス】
+      ・評価（素晴らしい、感心など）ではなく、驚きと共感を伝えてください。
+      ・「自分を大切に」「無理しないで」といった聞き飽きたアドバイスは禁止です。
+      ・「人生」「未来」「敬意」「尊い」などの重い言葉は封印してください。
+
+      【書き出しのルール】
+      ・システム側で既に「#{user.nickname}さん、」と呼びかけています。
+      ・あなたは名前を呼ばず、その後に続く温かいメッセージから書き始めてください。「あなた」という言葉も厳禁です。
+
+      【メッセージの構成】
+      1. 【時間帯に合わせた等身大のねぎらい】
+        「夜遅くまで本当にお疲れさま」や「今日もしっかり進んでいて嬉しいです」など、今の#{user.nickname}さんの状況に「体温」を乗せて話しかけてください。
+      2. 【凄さの代弁】
+         #{situation_context}の中、今日こうしてアプリを開いて記録に向き合っていること自体が「並外れたガッツ」であると、褒めてください。一般論ではなく、「ずっと見てきた存在」としての実感を込めて、あなた自身の言葉で伝えてください。
+      3. 【ぽぽねこの気持ち】
+         「会えて嬉しい」「顔が見られて安心した」など、バディとしての素直な感情を一言入れてください。
+      4. 【短い結び】
+         余計な助言はせず、肩の力が抜けるような一言で締めてください。
+
+【NGワード（絶対に使わないでください）】
+・「素晴らしい」「感心しています」「敬意を表します」などの、上から目線の評価。
+・「安らぎのひととき」「未来は明るい」などの、実体のない綺麗事。
+・「自分を大切に」「無理しないで」などの、聞き飽きたアドバイス。
+
+      【制約】
+      ・冒頭の「#{user.nickname}さん、」はシステム側で付けるので、あなたは名前を呼ばずに書き始めてください。
+      ・80文字〜120文字程度。短く、友達のような距離感で。
+      【制約】
+      ・猫語、猫の仕草、豆知識、特定の他社サービス名やキャラ名は一切禁止です。
+      ・100文字〜150文字程度。体温が感じられ、かつ知性と品格のある文章を。
+      ・「人生」「未来」「敬意」「尊い」などの重たい単語は封印してください。
+    TEXT
+  end
+  def self.build_user_context(user)
+  now = Time.current.in_time_zone("Asia/Tokyo")
+
+  lines = []
+
+  # 時間情報
+  lines << "現在は#{now.strftime('%H:%M')}です。"
+
+  # 育児モード
+  if user.childcare_mode
+    lines << "ユーザーは現在、育児サポートモードを利用しています。"
+  end
+
+  # 今日記録したか（Weightモデル想定）
+  if user.respond_to?(:weights)
+    if user.weights.where(created_at: Time.zone.today.all_day).exists?
+      lines << "今日はすでに記録をつけています。"
+    else
+      lines << "今日はまだ記録をつけていません。"
+    end
+  end
+
+  # 最後に依頼
+  lines << "これらを踏まえて、短く温かい一言を届けてください。"
+
+  lines.join("\n")
+end
+end

--- a/db/migrate/20260223122042_add_buddy_columns_to_users.rb
+++ b/db/migrate/20260223122042_add_buddy_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddBuddyColumnsToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :buddy_memo, :text
+    add_column :users, :last_buddy_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_22_102949) do
+ActiveRecord::Schema[7.2].define(version: 2026_02_23_122042) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -103,6 +103,8 @@ ActiveRecord::Schema[7.2].define(version: 2026_02_22_102949) do
     t.boolean "is_growth_record_enabled", default: true, null: false
     t.string "nickname"
     t.boolean "childcare_mode", default: false
+    t.text "buddy_memo"
+    t.datetime "last_buddy_updated_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
# 概要
バディからのメッセージ表示機能を実装しました。ユーザーの生活リズムに合わせた時間帯別の更新ロジックと、親近感のあるメッセージ生成を導入しています。

# 実装内容
- Time.currentを用いた朝・昼・夜の時間枠（スロット）判定ロジックの追加
- 同一時間枠内での無駄なAPIコールを抑制するキャッシュ（buddy_memo）機能の構築
- 評価や断定を避け、共感とねぎらいに特化したOpenAIシステムプロンプトの洗練
- 育児モードや記録状況に応じた動的なコンテキスト生成

Closes #132